### PR TITLE
ENH: Add option to save outputs to given filename

### DIFF
--- a/apybiomart/apybiomart.py
+++ b/apybiomart/apybiomart.py
@@ -7,56 +7,69 @@ from .classes import MartServer, DatasetServer, AttributesServer, \
     FiltersServer, Query
 
 
-def find_marts(save: bool = False) -> pd.DataFrame:
+def find_marts(save: bool = False,
+               output: str = "apybiomart_marts.csv") -> pd.DataFrame:
     """Retrieve and list available marts.
 
     Args:
         save: save results to a CSV file [default: False]
+        output: output filename if saving results
+            [default: 'apybiomart_marts.csv']
     """
-    server = MartServer(save=save)
+    server = MartServer(save=save, output=output)
     return server.find_marts()
 
 
 def find_datasets(mart: str = "ENSEMBL_MART_ENSEMBL",
-                  save: bool = False) -> pd.DataFrame:
+                  save: bool = False,
+                  output: str = "apybiomart_datasets.csv") -> pd.DataFrame:
     """Retrieve and list available datasets for a given mart.
 
     Args:
         mart: BioMart mart name (default: "ENSEMBL_MART_ENSEMBL")
         save: save results to a CSV file [default: False]
+        output: output filename if saving results
+            [default: 'apybiomart_datasets.csv']
     """
-    server = DatasetServer(mart, save=save)
+    server = DatasetServer(mart, save=save, output=output)
     return server.find_datasets()
 
 
 def find_attributes(dataset: str = "hsapiens_gene_ensembl",
-                    save: bool = False) -> pd.DataFrame:
+                    save: bool = False,
+                    output: str = "apybiomart_attributes.csv") -> pd.DataFrame:
     """Retrieve and list available attributes for a given mart.
 
     Args:
         dataset: BioMart dataset name (default: "hsapiens_gene_ensembl")
         save: save results to a CSV file [default: False]
+        output: output filename if saving results
+            [default: 'apybiomart_attributes.csv']
     """
-    server = AttributesServer(dataset, save=save)
+    server = AttributesServer(dataset, save=save, output=output)
     return server.find_attributes()
 
 
 def find_filters(dataset: str = "hsapiens_gene_ensembl",
-                 save: bool = False) -> pd.DataFrame:
+                 save: bool = False,
+                 output: str = "apybiomart_filters.csv") -> pd.DataFrame:
     """Retrieve and list available filters for a given mart.
 
     Args:
         dataset: BioMart dataset name (default: "hsapiens_gene_ensembl")
         save: save results to a CSV file [default: False]
+        output: output filename if saving results
+            [default: 'apybiomart_filters.csv']
     """
-    server = FiltersServer(dataset, save=save)
+    server = FiltersServer(dataset, save=save, output=output)
     return server.find_filters()
 
 
 def query(attributes: List[str],
           filters: Dict[str, Union[str, int, list, tuple, bool]],
           dataset: str = "hsapiens_gene_ensembl",
-          save: bool = False) -> pd.DataFrame:
+          save: bool = False,
+          output: str = "apybiomart_query.csv") -> pd.DataFrame:
     """Launch synchronous query using the given attributes, filters and dataset.
 
     Args:
@@ -64,15 +77,18 @@ def query(attributes: List[str],
         filters: dict of filter name : value to filter results
         dataset: BioMart dataset name (default: "hsapiens_gene_ensembl")
         save: save results to a CSV file [default: False]
+        output: output filename if saving results
+            [default: 'apybiomart_query.csv']
     """
-    server = Query(attributes, filters, dataset, save=save)
+    server = Query(attributes, filters, dataset, save=save, output=output)
     return server.query()
 
 
 async def aquery(attributes: List[str],
                  filters: Dict[str, Union[str, int, list, tuple, bool]],
                  dataset: str = "hsapiens_gene_ensembl",
-                 save: bool = False) -> pd.DataFrame:
+                 save: bool = False,
+                 output: str = "apybiomart_aquery.csv") -> pd.DataFrame:
     """Launch asynchronous query using the given attributes, filters and dataset.
 
     Args:
@@ -80,6 +96,8 @@ async def aquery(attributes: List[str],
         filters: dict of filter name : value to filter results
         dataset: BioMart dataset name (default: "hsapiens_gene_ensembl")
         save: save results to a CSV file [default: False]
+        output: output filename if saving results
+            [default: 'apybiomart_aquery.csv']
     """
-    server = Query(attributes, filters, dataset, save=save)
+    server = Query(attributes, filters, dataset, save=save, output=output)
     return await server.aquery()

--- a/apybiomart/classes.py
+++ b/apybiomart/classes.py
@@ -22,13 +22,16 @@ class _Server:
     Attributes:
         host: URL to connect to
         save: save results to a CSV file [default: False]
+        output: output filename if saving results [default: None]
     """
 
     def __init__(self,
                  host: str = "http://www.ensembl.org/biomart/martservice",
-                 save: bool = False):
+                 save: bool = False,
+                 output: Optional[str] = None):
         self.host = host
         self.save = save
+        self.output = output
         if not self._check_connection():
             raise _BiomartException("No internet connection available!")
 
@@ -80,8 +83,10 @@ class _Server:
 class MartServer(_Server):
     """Class used to retrieve and list available marts."""
 
-    def __init__(self, save: bool = False):
-        super().__init__(save=save)
+    def __init__(self,
+                 save: bool = False,
+                 output: str = "apybiomart_marts.csv"):
+        super().__init__(save=save, output=output)
 
     def find_marts(self) -> pd.DataFrame:
         """Return the list of available marts as a dataframe.
@@ -94,7 +99,7 @@ class MartServer(_Server):
         df.columns = ["Mart_ID", "Mart_name"]
         df.replace(pd.np.nan, "", inplace=True)
         if self.save:
-            df.to_csv("apybiomart_marts.csv", index=False)
+            df.to_csv(self.output, index=False)
 
         return df
 
@@ -138,8 +143,11 @@ class DatasetServer(_Server):
         mart: BioMart mart name
     """
 
-    def __init__(self, mart: str, save: bool = False):
-        super().__init__(save=save)
+    def __init__(self,
+                 mart: str,
+                 save: bool = False,
+                 output: str = "apybiomart_datasets.csv"):
+        super().__init__(save=save, output=output)
         self.mart = mart
 
     def find_datasets(self) -> pd.DataFrame:
@@ -156,7 +164,7 @@ class DatasetServer(_Server):
         df.columns = ["Dataset_ID", "Dataset_name", "Mart_ID"]
         df.replace(pd.np.nan, "", inplace=True)
         if self.save:
-            df.to_csv("apybiomart_datasets.csv", index=False)
+            df.to_csv(self.output, index=False)
 
         return df
 
@@ -182,8 +190,11 @@ class AttributesServer(_Server):
         dataset: BioMart dataset name
     """
 
-    def __init__(self, dataset: str, save: bool = False):
-        super().__init__(save=save)
+    def __init__(self,
+                 dataset: str,
+                 save: bool = False,
+                 output: str = "apybiomart_attributes.csv"):
+        super().__init__(save=save, output=output)
         self.dataset = dataset
 
     def find_attributes(self) -> pd.DataFrame:
@@ -198,7 +209,7 @@ class AttributesServer(_Server):
                       "Attribute_description", "Dataset_ID"]
         df.replace(pd.np.nan, "", inplace=True)
         if self.save:
-            df.to_csv("apybiomart_attributes.csv", index=False)
+            df.to_csv(self.output, index=False)
 
         return df
 
@@ -249,8 +260,11 @@ class FiltersServer(_Server):
         dataset: BioMart dataset name
     """
 
-    def __init__(self, dataset: str, save: bool = False):
-        super().__init__(save=save)
+    def __init__(self,
+                 dataset: str,
+                 save: bool = False,
+                 output: str = "apybiomart_filters.csv"):
+        super().__init__(save=save, output=output)
         self.dataset = dataset
 
     def find_filters(self) -> pd.DataFrame:
@@ -265,7 +279,7 @@ class FiltersServer(_Server):
                       "Filter_description", "Dataset_ID"]
         df.replace(pd.np.nan, "", inplace=True)
         if self.save:
-            df.to_csv("apybiomart_filters.csv", index=False)
+            df.to_csv(self.output, index=False)
 
         return df
 
@@ -321,8 +335,9 @@ class Query(_Server):
                  attributes: List[str],
                  filters: Dict[str, Union[str, int, list, tuple, bool]],
                  dataset: str,
-                 save: bool = False):
-        super().__init__(save=save)
+                 save: bool = False,
+                 output: str = "apybiomart_query.csv"):
+        super().__init__(save=save, output=output)
         self.attributes = attributes
         self.filters = filters
         self.dataset = dataset
@@ -377,7 +392,7 @@ class Query(_Server):
         result.replace(pd.np.nan, "", inplace=True)
 
         if self.save:
-            result.to_csv("apybiomart_query.csv", index=False)
+            result.to_csv(self.output, index=False)
 
         return result
 
@@ -431,7 +446,7 @@ class Query(_Server):
         result.replace(pd.np.nan, "", inplace=True)
 
         if self.save:
-            result.to_csv("apybiomart_aquery.csv", index=False)
+            result.to_csv(self.output, index=False)
 
         return result
 

--- a/apybiomart/commands/attributes.py
+++ b/apybiomart/commands/attributes.py
@@ -9,13 +9,15 @@ from apybiomart.apybiomart import find_attributes
 
 @click.command("attributes")
 @click.option("--dataset", default="hsapiens_gene_ensembl", type=str,
-              help="BioMart dataset name (default: 'hsapiens_gene_ensembl')")
+              help="BioMart dataset name", show_default=True)
 @click.option("--save", "-s", default=False, is_flag=True,
-              help="Save results to a CSV file [default: False]")
-def cli_attributes(dataset, save):
+              help="Save results to a CSV file", show_default=True)
+@click.option("--output", "-o", default="apybiomart_attributes.csv", type=str,
+              help="Output filename if saving results", show_default=True)
+def cli_attributes(dataset, save, output):
     """Retrieve and list available attributes for a given mart."""
     pd.set_option("max_rows", 999)
-    attributes = find_attributes(dataset, save=save)
+    attributes = find_attributes(dataset, save=save, output=output)
     attributes.columns = [col.replace("_", " ") for col in attributes.columns]
     click.echo(attributes)
     return 0

--- a/apybiomart/commands/datasets.py
+++ b/apybiomart/commands/datasets.py
@@ -9,13 +9,15 @@ from apybiomart.apybiomart import find_datasets
 
 @click.command("datasets")
 @click.option("--mart", default="ENSEMBL_MART_ENSEMBL", type=str,
-              help="BioMart mart name (default: 'ENSEMBL_MART_ENSEMBL')")
+              help="BioMart mart name", show_default=True)
 @click.option("--save", "-s", default=False, is_flag=True,
-              help="Save results to a CSV file [default: False]")
-def cli_datasets(mart, save):
+              help="Save results to a CSV file", show_default=True)
+@click.option("--output", "-o", default="apybiomart_datasets.csv", type=str,
+              help="Output filename if saving results", show_default=True)
+def cli_datasets(mart, save, output):
     """Retrieve and list available datasets for a given mart."""
     pd.set_option("max_rows", 999)
-    datasets = find_datasets(mart, save=save)
+    datasets = find_datasets(mart, save=save, output=output)
     datasets.columns = [col.replace("_", " ") for col in datasets.columns]
     click.echo(datasets)
     return 0

--- a/apybiomart/commands/filters.py
+++ b/apybiomart/commands/filters.py
@@ -9,13 +9,15 @@ from apybiomart.apybiomart import find_filters
 
 @click.command("filters")
 @click.option("--dataset", default="hsapiens_gene_ensembl", type=str,
-              help="BioMart dataset name (default: 'hsapiens_gene_ensembl')")
+              help="BioMart dataset name", show_default=True)
 @click.option("--save", "-s", default=False, is_flag=True,
-              help="Save results to a CSV file [default: False]")
-def cli_filters(dataset, save):
+              help="Save results to a CSV file", show_default=True)
+@click.option("--output", "-o", default="apybiomart_filters.csv", type=str,
+              help="Output filename if saving results", show_default=True)
+def cli_filters(dataset, save, output):
     """Retrieve and list available filters for a given mart."""
     pd.set_option("max_rows", 999)
-    filters = find_filters(dataset, save=save)
+    filters = find_filters(dataset, save=save, output=output)
     filters.columns = [col.replace("_", " ") for col in filters.columns]
     click.echo(filters)
     return 0

--- a/apybiomart/commands/marts.py
+++ b/apybiomart/commands/marts.py
@@ -9,11 +9,13 @@ from apybiomart.apybiomart import find_marts
 
 @click.command("marts")
 @click.option("--save", "-s", default=False, is_flag=True,
-              help="Save results to a CSV file [default: False]")
-def cli_marts(save):
+              help="Save results to a CSV file", show_default=True)
+@click.option("--output", "-o", default="apybiomart_marts.csv", type=str,
+              help="Output filename if saving results", show_default=True)
+def cli_marts(save, output):
     """Retrieve and list available marts."""
     pd.set_option("max_rows", 999)
-    marts = find_marts(save=save)
+    marts = find_marts(save=save, output=output)
     marts.columns = [col.replace("_", " ") for col in marts.columns]
     click.echo(marts)
     return 0

--- a/apybiomart/tests/test_aquery.py
+++ b/apybiomart/tests/test_aquery.py
@@ -48,6 +48,28 @@ def test_aquery_save(df_query_ensembl_hsapiens_gene_chrom_2):
         os.remove("apybiomart_aquery.csv")
 
 
+def test_aquery_output(df_query_ensembl_hsapiens_gene_chrom_2):
+    """Test the saved async query results with the given filename for the
+    default dataset (hsapiens_gene_ensembl)."""
+    expect = (df_query_ensembl_hsapiens_gene_chrom_2
+              .reset_index(drop=True))
+
+    loop = asyncio.get_event_loop()
+    result = loop.run_until_complete(
+        aquery(attributes=["ensembl_gene_id", "external_gene_name"],
+               filters={"chromosome_name": "2"},
+               save=True, output="tested.csv")
+    )
+    saved = (pd.read_csv("tested.csv")
+             .replace(pd.np.nan, "")
+             .reset_index(drop=True))
+
+    try:
+        assert_frame_equal(saved, expect)
+    finally:
+        os.remove("tested.csv")
+
+
 def test_aquery_default_int(df_query_ensembl_hsapiens_gene_chrom_2):
     """Test the async query results for the default dataset
     (hsapiens_gene_ensembl) with int filters parameter."""

--- a/apybiomart/tests/test_attributes.py
+++ b/apybiomart/tests/test_attributes.py
@@ -42,6 +42,25 @@ def test_find_attributes_save(df_attributes_ensembl_hsapiens_gene):
         os.remove("apybiomart_attributes.csv")
 
 
+def test_find_attributes_output(df_attributes_ensembl_hsapiens_gene):
+    """Test the available attributes returned by find_attributes with a given
+    filename for the default dataset (hsapiens_gene_ensembl)."""
+    expect = (df_attributes_ensembl_hsapiens_gene
+              .sort_values(by="Attribute_ID", axis=0)
+              .reset_index(drop=True))
+    _ = find_attributes(save=True, output="tested.csv")
+    saved = pd.read_csv("tested.csv")
+    result = (saved
+              .replace(pd.np.nan, "")
+              .sort_values(by="Attribute_ID", axis=0)
+              .reset_index(drop=True))
+
+    try:
+        assert_frame_equal(result, expect)
+    finally:
+        os.remove("tested.csv")
+
+
 def test_find_attributes_ensembl(df_attributes_ensembl_hsapiens_gene):
     """Test the available attributes returned by find_attributes() for the
     hsapiens_gene_ensembl dataset."""

--- a/apybiomart/tests/test_cli_attributes.py
+++ b/apybiomart/tests/test_cli_attributes.py
@@ -32,6 +32,19 @@ def test_cli_attributes_save():
         os.remove("apybiomart_attributes.csv")
 
 
+def test_cli_attributes_output():
+    """Test the saved attributes returned by apybiomart attributes with a
+    given filename for the default dataset (hsapiens_gene_ensembl)."""
+    runner = CliRunner()
+    result = runner.invoke(cli.main, ["attributes", "--save",
+                                      "--output", "tested.csv"])
+    try:
+        assert result.exit_code == 0
+        assert os.path.isfile("tested.csv")
+    finally:
+        os.remove("tested.csv")
+
+
 def test_cli_attributes_ontology():
     """Test the available attributes returned by apybiomart attributes for the
     closure_ECO dataset."""

--- a/apybiomart/tests/test_cli_datasets.py
+++ b/apybiomart/tests/test_cli_datasets.py
@@ -32,6 +32,19 @@ def test_cli_datasets_save():
         os.remove("apybiomart_datasets.csv")
 
 
+def test_cli_datasets_output():
+    """Test the saved datasets returned by apybiomart datasets with a given
+    filename for the default mart (ENSEMBL_MART_ENSEMBL)."""
+    runner = CliRunner()
+    result = runner.invoke(cli.main, ["datasets", "--save",
+                                      "--output", "tested.csv"])
+    try:
+        assert result.exit_code == 0
+        assert os.path.isfile("tested.csv")
+    finally:
+        os.remove("tested.csv")
+
+
 def test_cli_datasets_mouse():
     """Test the available datasets returned by apybiomart datasets for the
     ENSEMBL_MART_MOUSE mart."""

--- a/apybiomart/tests/test_cli_filters.py
+++ b/apybiomart/tests/test_cli_filters.py
@@ -32,6 +32,19 @@ def test_cli_filters_saved():
         os.remove("apybiomart_filters.csv")
 
 
+def test_cli_filters_output():
+    """Test the saved attributes returned by apybiomart filters with a given
+    filename for the default dataset (hsapiens_gene_ensembl)."""
+    runner = CliRunner()
+    result = runner.invoke(cli.main, ["filters", "--save",
+                                      "--output", "tested.csv"])
+    try:
+        assert result.exit_code == 0
+        assert os.path.isfile("tested.csv")
+    finally:
+        os.remove("tested.csv")
+
+
 def test_cli_filters_ontology():
     """Test the available attributes returned by apybiomart filters for the
     closure_ECO dataset."""

--- a/apybiomart/tests/test_cli_marts.py
+++ b/apybiomart/tests/test_cli_marts.py
@@ -28,3 +28,16 @@ def test_cli_marts_save():
         assert os.path.isfile("apybiomart_marts.csv")
     finally:
         os.remove("apybiomart_marts.csv")
+
+
+def test_cli_marts_output():
+    """Test the available marts saved by apybiomart marts with a given
+    filename."""
+    runner = CliRunner()
+    result = runner.invoke(cli.main, ["marts", "--save",
+                                      "--output", "tested.csv"])
+    try:
+        assert result.exit_code == 0
+        assert os.path.isfile("tested.csv")
+    finally:
+        os.remove("tested.csv")

--- a/apybiomart/tests/test_datasets.py
+++ b/apybiomart/tests/test_datasets.py
@@ -42,6 +42,25 @@ def test_find_datasets_save(df_datasets_ensembl):
         os.remove("apybiomart_datasets.csv")
 
 
+def test_find_datasets_output(df_datasets_ensembl):
+    """Test the available datasets returned by find_datasets with a given
+    filename for the default mart (ENSEMBL_MART_ENSEMBL)."""
+    expect = (df_datasets_ensembl
+              .sort_values(by="Dataset_ID", axis=0)
+              .reset_index(drop=True))
+    _ = find_datasets(save=True, output="tested.csv")
+    saved = pd.read_csv("tested.csv")
+    result = (saved
+              .replace(pd.np.nan, "")
+              .sort_values(by="Dataset_ID", axis=0)
+              .reset_index(drop=True))
+
+    try:
+        assert_frame_equal(result, expect)
+    finally:
+        os.remove("tested.csv")
+
+
 def test_find_datasets_ensembl(df_datasets_ensembl):
     """Test the available datasets returned by find_datasets() for the
     ENSEMBL_MART_ENSEMBL mart."""

--- a/apybiomart/tests/test_filters.py
+++ b/apybiomart/tests/test_filters.py
@@ -42,6 +42,25 @@ def test_find_filters_save(df_filters_ensembl_hsapiens_gene):
         os.remove("apybiomart_filters.csv")
 
 
+def test_find_filters_output(df_filters_ensembl_hsapiens_gene):
+    """Test the available filters returned by find_filters with a given
+    filename for the default dataset (hsapiens_gene_ensembl)."""
+    expect = (df_filters_ensembl_hsapiens_gene
+              .sort_values(by="Filter_ID", axis=0)
+              .reset_index(drop=True))
+    _ = find_filters(save=True, output="tested.csv")
+    saved = pd.read_csv("tested.csv")
+    result = (saved
+              .replace(pd.np.nan, "")
+              .sort_values(by="Filter_ID", axis=0)
+              .reset_index(drop=True))
+
+    try:
+        assert_frame_equal(result, expect)
+    finally:
+        os.remove("tested.csv")
+
+
 def test_find_filters_ensembl(df_filters_ensembl_hsapiens_gene):
     """Test the available filters returned by find_filters() for the
     hsapiens_gene_ensembl dataset."""

--- a/apybiomart/tests/test_marts.py
+++ b/apybiomart/tests/test_marts.py
@@ -38,3 +38,21 @@ def test_find_marts_save(df_marts):
         assert_frame_equal(result, expect)
     finally:
         os.remove("apybiomart_marts.csv")
+
+
+def test_find_marts_output(df_marts):
+    """Test the available marts returned by find_marts with a given filename."""
+    expect = (df_marts
+              .sort_values(by="Mart_ID", axis=0)
+              .reset_index(drop=True))
+    _ = find_marts(save=True, output="tested.csv")
+    saved = pd.read_csv("tested.csv")
+    result = (saved
+              .replace(pd.np.nan, "")
+              .sort_values(by="Mart_ID", axis=0)
+              .reset_index(drop=True))
+
+    try:
+        assert_frame_equal(result, expect)
+    finally:
+        os.remove("tested.csv")

--- a/apybiomart/tests/test_query.py
+++ b/apybiomart/tests/test_query.py
@@ -40,6 +40,25 @@ def test_query_save(df_query_ensembl_hsapiens_gene_chrom_2):
         os.remove("apybiomart_query.csv")
 
 
+def test_query_output(df_query_ensembl_hsapiens_gene_chrom_2):
+    """Test the saved query results with a given filename for the default
+    dataset (hsapiens_gene_ensembl)."""
+    expect = (df_query_ensembl_hsapiens_gene_chrom_2
+              .reset_index(drop=True))
+    _ = query(attributes=["ensembl_gene_id", "external_gene_name"],
+              filters={"chromosome_name": "2"},
+              save=True, output="tested.csv")
+    saved = pd.read_csv("tested.csv")
+    result = (saved
+              .replace(pd.np.nan, "")
+              .reset_index(drop=True))
+
+    try:
+        assert_frame_equal(result, expect)
+    finally:
+        os.remove("tested.csv")
+
+
 def test_query_default_int(df_query_ensembl_hsapiens_gene_chrom_2):
     """Test the query results for the default dataset (hsapiens_gene_ensembl)
     with int filters parameter."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ watchdog==0.9.0
 flake8==3.7.9
 tox==3.14.3
 coverage==5.0.3
-codecov==2.0.16
+codecov==2.0.21
 Sphinx==2.3.1
 sphinxcontrib-napoleon==0.7
 twine==3.1.1


### PR DESCRIPTION
Closes #57 

The CLI option `--output` and the module `output` argument now allow users to specify a filename to save outputs; if not provided, the default filename will be used.

TEMP: tests will fail as Biomart is currently under maintenance.